### PR TITLE
fix: fix typo 'scalibility' to 'scalability' in fixtures

### DIFF
--- a/packages/cli/resources/resume.yml
+++ b/packages/cli/resources/resume.yml
@@ -82,7 +82,7 @@ content:
         - Actively participated in code reviews, providing valuable feedback to improve code quality and adherence to best practices
         - Mentored and guided junior developers, fostering a collaborative and growth-oriented team environment
       keywords:
-        - Scalibility
+        - Scalability
         - Growth
         - Quality
         - Mentorship

--- a/packages/cli/src/commands/fixtures/software-engineer.yml
+++ b/packages/cli/src/commands/fixtures/software-engineer.yml
@@ -97,7 +97,7 @@ content:
         - Actively participated in code reviews, providing valuable feedback to improve code quality and adherence to best practices
         - Mentored and guided junior developers, fostering a collaborative and growth-oriented team environment
       keywords:
-        - Scalibility
+        - Scalability
         - Growth
         - Quality
         - Mentorship

--- a/packages/core/src/renderer/fixtures/full-resume.yml
+++ b/packages/core/src/renderer/fixtures/full-resume.yml
@@ -97,7 +97,7 @@ content:
         - Actively participated in code reviews, providing valuable feedback to improve code quality and adherence to best practices
         - Mentored and guided junior developers, fostering a collaborative and growth-oriented team environment
       keywords:
-        - Scalibility
+        - Scalability
         - Growth
         - Quality
         - Mentorship


### PR DESCRIPTION
This PR fixes a typo `scalibility` to `scalability` in some of the fixtures.

Loving what you guys are doing, keep it up! :heart: