### PR TITLE
fix(json2yamlresume): preserve JSON Resume summary for work, projects, volunteer

### DIFF
--- a/packages/json2yamlresume/src/converter.test.ts
+++ b/packages/json2yamlresume/src/converter.test.ts
@@ -263,6 +263,44 @@ describe(convertProjects, () => {
       },
     ])
   })
+
+  it('should preserve summary when projects have summary and no highlights', () => {
+    const projectsItem = {
+      name: 'Project With Summary',
+      description: 'A project with a summary paragraph',
+      summary: 'Led the architecture design for the platform.',
+    }
+
+    const resume = { projects: [projectsItem] }
+    const result = convertProjects(resume)
+
+    expect(result).toEqual([
+      {
+        ...projectsItem,
+        summary: 'Led the architecture design for the platform.',
+      },
+    ])
+  })
+
+  it('should merge summary and highlights when both are set', () => {
+    const projectsItem = {
+      name: 'Project Both',
+      description: 'A project with summary and highlights',
+      summary: 'Member of the Architecture Group.',
+      highlights: ['Shipped feature X', 'Led rewrite of service Y'],
+    }
+
+    const resume = { projects: [projectsItem] }
+    const result = convertProjects(resume)
+
+    expect(result).toEqual([
+      {
+        ...omit(projectsItem, ['highlights']),
+        summary:
+          'Member of the Architecture Group.\n\n- Shipped feature X\n- Led rewrite of service Y',
+      },
+    ])
+  })
 })
 
 describe(convertReferences, () => {
@@ -423,6 +461,44 @@ describe(convertVolunteer, () => {
       },
     ])
   })
+
+  it('should preserve summary when volunteer items have summary and no highlights', () => {
+    const volunteerItem = {
+      organization: 'Org With Summary',
+      position: 'Helper',
+      summary: 'Coordinated community outreach programs.',
+    }
+
+    const resume = { volunteer: [volunteerItem] }
+    const result = convertVolunteer(resume)
+
+    expect(result).toEqual([
+      {
+        ...volunteerItem,
+        summary: 'Coordinated community outreach programs.',
+      },
+    ])
+  })
+
+  it('should merge summary and highlights when both are set on volunteer items', () => {
+    const volunteerItem = {
+      organization: 'Org Both',
+      position: 'Lead',
+      summary: 'Organized annual fundraising events.',
+      highlights: ['Raised $50K', 'Recruited 30 volunteers'],
+    }
+
+    const resume = { volunteer: [volunteerItem] }
+    const result = convertVolunteer(resume)
+
+    expect(result).toEqual([
+      {
+        ...omit(volunteerItem, ['highlights']),
+        summary:
+          'Organized annual fundraising events.\n\n- Raised $50K\n- Recruited 30 volunteers',
+      },
+    ])
+  })
 })
 
 describe(convertWork, () => {
@@ -462,7 +538,7 @@ describe(convertWork, () => {
     expect(result).toEqual([
       {
         ...workItem,
-        summary: '',
+        summary: 'Did engineering',
       },
     ])
   })
@@ -497,11 +573,32 @@ describe(convertWork, () => {
     expect(result).toEqual([
       {
         ...omit(workItem1, 'highlights'),
-        summary: '- Did A\n- Did B',
+        summary: 'Worked on X\n\n- Did A\n- Did B',
       },
       {
         ...omit(workItem2, 'highlights'),
-        summary: '- Led C\n- Improved D',
+        summary: 'Worked on Y\n\n- Led C\n- Improved D',
+      },
+    ])
+  })
+
+  it('should preserve summary when work items have summary and no highlights', () => {
+    const workItem = {
+      company: 'Company D',
+      position: 'Architect',
+      startDate: '2021-01-01',
+      endDate: '2022-01-01',
+      summary: 'Member of the Architecture Group; established team standards.',
+    }
+
+    const resume = { ...jsonResume, work: [workItem] }
+    const result = convertWork(resume)
+
+    expect(result).toEqual([
+      {
+        ...workItem,
+        summary:
+          'Member of the Architecture Group; established team standards.',
       },
     ])
   })

--- a/packages/json2yamlresume/src/converter.ts
+++ b/packages/json2yamlresume/src/converter.ts
@@ -96,7 +96,7 @@ export function convertProjects(
   // @ts-ignore
   return projects.map((item) => ({
     ...omit(item, ['highlights']),
-    summary: mergeHighlightsIntoSummary('', item.highlights),
+    summary: mergeHighlightsIntoSummary(item.summary ?? '', item.highlights),
   }))
 }
 
@@ -132,7 +132,7 @@ export function convertVolunteer(
   // @ts-ignore
   return volunteer.map((item) => ({
     ...omit(item, ['highlights']),
-    summary: mergeHighlightsIntoSummary('', item.highlights),
+    summary: mergeHighlightsIntoSummary(item.summary ?? '', item.highlights),
   }))
 }
 
@@ -148,7 +148,7 @@ export function convertWork(resume: JSONResume): Resume['content']['work'] {
   // @ts-ignore
   return work.map((item) => ({
     ...omit(item, ['highlights']),
-    summary: mergeHighlightsIntoSummary('', item.highlights),
+    summary: mergeHighlightsIntoSummary(item.summary ?? '', item.highlights),
   }))
 }
 

--- a/packages/json2yamlresume/src/types.ts
+++ b/packages/json2yamlresume/src/types.ts
@@ -94,6 +94,7 @@ export type JSONResumeProjectItem = {
   highlights?: string[]
   name?: string
   startDate?: string
+  summary?: string
   url?: string
 }
 


### PR DESCRIPTION
## Summary

Fixes #225 — JSON Resume `summary` field on `work`, `projects`, and `volunteer` entries was silently discarded by the converter. Three caller sites passed `''` as the existing summary to `mergeHighlightsIntoSummary` instead of forwarding `item.summary`. The helper itself already handled all three behavioral cases correctly; only the callers needed to pass the summary through.

## Changes

- `packages/json2yamlresume/src/converter.ts`: pass `item.summary ?? ''` to `mergeHighlightsIntoSummary` in `convertWork`, `convertProjects`, and `convertVolunteer` (3 one-line changes)
- `packages/json2yamlresume/src/types.ts`: add missing `summary?: string` to `JSONResumeProjectItem` (present on `WorkItem` and `VolunteerItem`, absent here)
- `packages/json2yamlresume/src/converter.test.ts`: update two existing `convertWork` tests that asserted the buggy behavior; add 5 new tests covering the both-set and summary-only cases across all three converters
- Documentation: CHANGELOG not needed (auto-generated from conventional commits); README not needed (bug fix, no API change)

## Test Plan

- [x] All existing tests pass
- [x] New tests cover both-set and summary-only cases for all three converters
- [x] `pnpm --filter json2yamlresume build` succeeds

## Related

- Closes https://github.com/yamlresume/yamlresume/issues/225
