### PR TITLE
feat(core): extend project description maxLength from 128 to 1024

### DIFF
--- a/packages/core/src/schema/content/projects.test.ts
+++ b/packages/core/src/schema/content/projects.test.ts
@@ -238,6 +238,70 @@ describe('ProjectsSchema', () => {
           },
         },
       },
+      {
+        projects: [
+          // @ts-ignore
+          {
+            // description too short
+            name,
+            startDate,
+            summary,
+
+            description: 'abc',
+          },
+        ],
+        error: {
+          errors: [],
+          properties: {
+            projects: {
+              errors: [],
+              items: [
+                {
+                  errors: [],
+                  properties: {
+                    description: {
+                      errors: ['description should be 4 characters or more.'],
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        },
+      },
+      {
+        projects: [
+          // @ts-ignore
+          {
+            // description too long
+            name,
+            startDate,
+            summary,
+
+            description: 'a'.repeat(1025),
+          },
+        ],
+        error: {
+          errors: [],
+          properties: {
+            projects: {
+              errors: [],
+              items: [
+                {
+                  errors: [],
+                  properties: {
+                    description: {
+                      errors: [
+                        'description should be 1024 characters or less.',
+                      ],
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        },
+      },
     ]
 
     for (const { projects, error } of tests) {

--- a/packages/core/src/schema/content/projects.ts
+++ b/packages/core/src/schema/content/projects.ts
@@ -47,7 +47,7 @@ export const ProjectNameSchema = NameSchema('name').describe(
 export const ProjectDescriptionSchema = SizedStringSchema(
   'description',
   4,
-  128
+  1024
 ).meta({
   title: 'Description',
   description: 'A detailed description of the project and your role.',

--- a/packages/core/src/schema/schema.json
+++ b/packages/core/src/schema/schema.json
@@ -1276,7 +1276,7 @@
                       {
                         "type": "string",
                         "minLength": 4,
-                        "maxLength": 128,
+                        "maxLength": 1024,
                         "title": "[optional] Description",
                         "description": "A detailed description of the project and your role or `null`.",
                         "examples": [


### PR DESCRIPTION
## Summary

Relaxes the project `description` field's zod schema maxLength from 128 to 1024 characters, matching the limit already used by the `summary` field across work, projects, volunteer, and other sections. Real-world project descriptions routinely exceed 128 characters, causing spurious build warnings.

## Changes

- Project `description` maxLength raised from 128 to 1024 in the zod schema (`packages/core/src/schema/content/projects.ts`), with the JSON Schema snapshot regenerated accordingly (`packages/core/src/schema/schema.json`)
- Added boundary tests for description min length (4) and max length (1024) in `packages/core/src/schema/content/projects.test.ts`

## Test Plan

- [x] Projects schema tests pass (5 tests, including new min/max length boundary cases)
- [x] Resume schema tests pass (schema.json regenerated)
- [x] Full core test suite: 664/672 pass (8 pre-existing flaky failures in date/renderer tests, unrelated)

## Related

- Closes https://github.com/yamlresume/yamlresume/issues/234