### PR TITLE
feat(core): add Discord to NETWORK_OPTIONS

### DIFF
--- a/packages/core/src/models/options.ts
+++ b/packages/core/src/models/options.ts
@@ -227,6 +227,7 @@ export const LOCALE_LANGUAGE_OPTIONS = [
  */
 export const NETWORK_OPTIONS = [
   'Behance',
+  'Discord',
   'Dribbble',
   'Facebook',
   'GitHub',

--- a/packages/core/src/schema/schema.json
+++ b/packages/core/src/schema/schema.json
@@ -1152,6 +1152,7 @@
                     "type": "string",
                     "enum": [
                       "Behance",
+                      "Discord",
                       "Dribbble",
                       "Facebook",
                       "GitHub",


### PR DESCRIPTION
## Summary

Adds Discord to the NETWORK_OPTIONS array so that JSON Resume profiles listing a Discord network no longer produce a validation warning. The profile already rendered correctly. This fixes the validation gap only.

## Changes

- `'Discord'` added to NETWORK_OPTIONS in `packages/core/src/models/options.ts` between Behance and Dribbble (alphabetical order), with the JSON Schema snapshot regenerated accordingly (`packages/core/src/schema/schema.json`)

## Test Plan

- [x] Primitives schema tests pass (63 tests, including NETWORK_OPTIONS enumeration)
- [x] Full core test suite: 664/672 pass (8 pre-existing flaky failures in date/renderer tests, unrelated)

## Related

- Closes https://github.com/yamlresume/yamlresume/issues/235