### PR TITLE
feat(html): add id attributes to section elements for anchor navigation

### DIFF
--- a/packages/core/src/renderer/html/renderer.test.ts
+++ b/packages/core/src/renderer/html/renderer.test.ts
@@ -465,7 +465,7 @@ describe('HtmlRenderer', () => {
       const result = renderer.renderSummary()
 
       expect(result).toContain(
-        '<section class="resume-section" data-section="summary">'
+        '<section class="resume-section" id="summary" data-section="summary">'
       )
       expect(result).toContain('<div class="resume-section-content">')
       expect(result).toContain('<div class="resume-summary-content">')
@@ -693,6 +693,7 @@ describe('HtmlRenderer', () => {
       renderer = new HtmlRenderer(resume, layoutIndex)
       const result = renderer.renderEducation()
 
+      expect(result).toContain('id="education"')
       expect(result).toContain(`<a href="${url}">${institution}</a>`)
       expect(result).toContain(degree)
       expect(result).toContain(area)
@@ -748,6 +749,7 @@ describe('HtmlRenderer', () => {
       renderer = new HtmlRenderer(resume, layoutIndex)
       const result = renderer.renderWork()
 
+      expect(result).toContain('id="work"')
       expect(result).toContain(`<a href="${url}">${name}</a>`)
       expect(result).toContain(
         `<div class="resume-entry-title"><a href="${url}">${name}</a></div>`
@@ -801,7 +803,7 @@ describe('HtmlRenderer', () => {
       const result = renderer.renderLanguages()
 
       expect(result).toContain(
-        '<section class="resume-section" data-section="languages">'
+        '<section class="resume-section" id="languages" data-section="languages">'
       )
       expect(result).toContain(
         '<h2 class="resume-section-title">Languages</h2>'
@@ -892,7 +894,7 @@ describe('HtmlRenderer', () => {
       const result = renderer.renderSkills()
 
       expect(result).toContain(
-        '<section class="resume-section" data-section="skills">'
+        '<section class="resume-section" id="skills" data-section="skills">'
       )
       expect(result).toContain('<h2 class="resume-section-title">Skills</h2>')
       expect(result).toContain('<div class="resume-skill-item">')
@@ -1000,6 +1002,7 @@ describe('HtmlRenderer', () => {
       renderer = new HtmlRenderer(resume, layoutIndex)
       const result = renderer.renderAwards()
 
+      expect(result).toContain('id="awards"')
       expect(result).toContain(title)
       expect(result).toContain(awarder)
       expect(result).toContain('Jan 2023')
@@ -1046,6 +1049,7 @@ describe('HtmlRenderer', () => {
       renderer = new HtmlRenderer(resume, layoutIndex)
       const result = renderer.renderCertificates()
 
+      expect(result).toContain('id="certificates"')
       expect(result).toContain(issuer)
       expect(result).toContain('May 2023')
       expect(result).toContain(`<a href="${url}">${name}</a>`)
@@ -1093,6 +1097,7 @@ describe('HtmlRenderer', () => {
       renderer = new HtmlRenderer(resume, layoutIndex)
       const result = renderer.renderPublications()
 
+      expect(result).toContain('id="publications"')
       expect(result).toContain(`<a href="${url}">${name}</a>`)
       expect(result).toContain(
         `<div class="resume-entry-title"><a href="${url}">${name}</a></div>`
@@ -1145,6 +1150,7 @@ describe('HtmlRenderer', () => {
       renderer = new HtmlRenderer(resume, layoutIndex)
       const result = renderer.renderReferences()
 
+      expect(result).toContain('id="references"')
       // Verify Name is Linked to Email
       expect(result).toContain(`<a href="mailto:${email}">${name}</a>`)
 
@@ -1207,6 +1213,7 @@ describe('HtmlRenderer', () => {
       renderer = new HtmlRenderer(resume, layoutIndex)
       const result = renderer.renderProjects()
 
+      expect(result).toContain('id="projects"')
       expect(result).toContain(`<a href="${url}">${name}</a>`)
       // Verify Name is Title (Bold)
       expect(result).toContain(
@@ -1262,7 +1269,7 @@ describe('HtmlRenderer', () => {
       const result = renderer.renderInterests()
 
       expect(result).toContain(
-        '<section class="resume-section" data-section="interests">'
+        '<section class="resume-section" id="interests" data-section="interests">'
       )
       expect(result).toContain(
         '<h2 class="resume-section-title">Interests</h2>'
@@ -1345,6 +1352,7 @@ describe('HtmlRenderer', () => {
       renderer = new HtmlRenderer(resume, layoutIndex)
       const result = renderer.renderVolunteer()
 
+      expect(result).toContain('id="volunteer"')
       expect(result).toContain(`<a href="${url}">${organization}</a>`)
       expect(result).toContain(
         `<div class="resume-entry-title"><a href="${url}">${organization}</a></div>`

--- a/packages/core/src/renderer/html/renderer.ts
+++ b/packages/core/src/renderer/html/renderer.ts
@@ -231,7 +231,7 @@ ${this.getStyles()}
       return ''
     }
 
-    return `<section class="resume-section" data-section="summary">
+    return `<section class="resume-section" id="summary" data-section="summary">
       <h2 class="resume-section-title">${sectionNames.basics}</h2>
       <div class="resume-section-content">
         <div class="resume-summary-content">${summary}</div>
@@ -383,7 +383,7 @@ ${this.getStyles()}
       }
     )
 
-    return `<section class="resume-section" data-section="education">
+    return `<section class="resume-section" id="education" data-section="education">
       <h2 class="resume-section-title">${sectionNames.education}</h2>
       <div class="resume-section-content">
         ${educationEntries.join('\n')}
@@ -459,7 +459,7 @@ ${this.getStyles()}
       }
     )
 
-    return `<section class="resume-section" data-section="work">
+    return `<section class="resume-section" id="work" data-section="work">
       <h2 class="resume-section-title">${sectionNames.work}</h2>
       <div class="resume-section-content">
         ${workEntries.join('\n')}
@@ -511,7 +511,7 @@ ${this.getStyles()}
         )
     )
 
-    return `<section class="resume-section" data-section="languages">
+    return `<section class="resume-section" id="languages" data-section="languages">
       <h2 class="resume-section-title">${sectionNames.languages}</h2>
       <div class="resume-section-content">
         <div class="resume-languages-list">
@@ -568,7 +568,7 @@ ${this.getStyles()}
       )
     )
 
-    return `<section class="resume-section" data-section="skills">
+    return `<section class="resume-section" id="skills" data-section="skills">
       <h2 class="resume-section-title">${sectionNames.skills}</h2>
       <div class="resume-section-content">
         ${skillItems.join('\n')}
@@ -625,7 +625,7 @@ ${this.getStyles()}
       }
     )
 
-    return `<section class="resume-section" data-section="awards">
+    return `<section class="resume-section" id="awards" data-section="awards">
       <h2 class="resume-section-title">${sectionNames.awards}</h2>
       <div class="resume-section-content">
         ${awardEntries.join('\n')}
@@ -680,7 +680,7 @@ ${this.getStyles()}
       }
     )
 
-    return `<section class="resume-section" data-section="certificates">
+    return `<section class="resume-section" id="certificates" data-section="certificates">
       <h2 class="resume-section-title">${sectionNames.certificates}</h2>
       <div class="resume-section-content">
         ${certificateEntries.join('\n')}
@@ -739,7 +739,7 @@ ${this.getStyles()}
       }
     )
 
-    return `<section class="resume-section" data-section="publications">
+    return `<section class="resume-section" id="publications" data-section="publications">
       <h2 class="resume-section-title">${sectionNames.publications}</h2>
       <div class="resume-section-content">
         ${publicationEntries.join('\n')}
@@ -797,7 +797,7 @@ ${this.getStyles()}
       }
     )
 
-    return `<section class="resume-section" data-section="references">
+    return `<section class="resume-section" id="references" data-section="references">
       <h2 class="resume-section-title">${sectionNames.references}</h2>
       <div class="resume-section-content">
         ${referenceEntries.join('\n')}
@@ -873,7 +873,7 @@ ${this.getStyles()}
       }
     )
 
-    return `<section class="resume-section" data-section="projects">
+    return `<section class="resume-section" id="projects" data-section="projects">
       <h2 class="resume-section-title">${sectionNames.projects}</h2>
       <div class="resume-section-content">
         ${projectEntries.join('\n')}
@@ -915,7 +915,7 @@ ${this.getStyles()}
       )
     )
 
-    return `<section class="resume-section" data-section="interests">
+    return `<section class="resume-section" id="interests" data-section="interests">
       <h2 class="resume-section-title">${sectionNames.interests}</h2>
       <div class="resume-section-content">
         ${interestItems.join('\n')}
@@ -981,7 +981,7 @@ ${this.getStyles()}
       }
     )
 
-    return `<section class="resume-section" data-section="volunteer">
+    return `<section class="resume-section" id="volunteer" data-section="volunteer">
       <h2 class="resume-section-title">${sectionNames.volunteer}</h2>
       <div class="resume-section-content">
         ${volunteerEntries.join('\n')}


### PR DESCRIPTION
## Summary

Adds `id` attributes to every `<section>` element emitted by the HTML renderer, enabling native browser anchor navigation. A URL fragment like `#awards` now scrolls directly to the Awards section with zero JavaScript. The `id` values match the existing `data-section` values exactly.

## Changes

- 12 `<section>` elements in `packages/core/src/renderer/html/renderer.ts` now emit `id="<name>"` alongside `data-section="<name>"` (summary, education, work, languages, skills, awards, certificates, publications, references, projects, interests, volunteer)
- 12 test assertions in `packages/core/src/renderer/html/renderer.test.ts` verify the new `id` attributes across all sections

## Test Plan

- [x] HTML renderer tests: 71/76 pass (5 pre-existing date-formatting failures unrelated)

## Related

- Closes https://github.com/yamlresume/yamlresume/issues/239