### PR TITLE
fix(html): stack calm template skills vertically when using keywords

### DIFF
--- a/packages/core/src/renderer/html/styles/calm.css
+++ b/packages/core/src/renderer/html/styles/calm.css
@@ -179,8 +179,7 @@ a:hover {
 .resume-skill-item,
 .resume-language-item {
   display: flex;
-  align-items: baseline;
-  justify-content: space-between;
+  flex-direction: column;
   margin-bottom: var(--spacing-xs);
 }
 
@@ -211,12 +210,6 @@ a:hover {
 
   .resume-entry-header {
     flex-wrap: wrap;
-  }
-
-  .resume-skill-item,
-  .resume-language-item {
-    flex-direction: column;
-    align-items: flex-start;
   }
 }
 


### PR DESCRIPTION
## Summary

The calm template's skills and languages sections used a side-by-side flex layout (`justify-content: space-between`) that broke when skills carried `keywords` (long comma-separated lists) instead of `level` (short strings). The keyword list was forced into a narrow right column, wrapping across many lines while the skill name sat orphaned on the left. This switches to a stacked vertical layout via `flex-direction: column`, matching the existing mobile behavior.

## Changes

- Skills with `keywords` now stack vertically on desktop instead of splitting into a broken two-column layout; languages get the same fix since they share the CSS rule
- Removed the now-redundant mobile breakpoint rules for `.resume-skill-item` and `.resume-language-item`; desktop and mobile now share the same stacked layout

## Test Plan

- [ ] All 71 existing renderer tests pass (8 pre-existing date/timezone failures unrelated to this change)
- [ ] Manual testing: render a resume with keyword-heavy skills (no `level` field) in the calm template; verify skills display as stacked rows on desktop viewports

## Related

- Closes https://github.com/yamlresume/yamlresume/issues/238

Generated by /finish-issue v2026.07.14.3@8469237 • [my-claude-skills](https://github.com/couimet/my-claude-skills)