### PR TITLE
docs: fix broken star history charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ Contributions are deeply appreciated! Please read the
 
 ### Star History
 
-[![YAMLResume Star History Chart](https://api.star-history.com/svg?repos=yamlresume/yamlresume&type=Date)](https://www.star-history.com/#yamlresume/yamlresume&Date)
+[![YAMLResume Star History Chart](https://star-history.dera.page/svg?repos=yamlresume/yamlresume&type=Date)](https://star-history.dera.page/#yamlresume/yamlresume&Date)
 
 ## Roadmap
 

--- a/readmes/README-de.md
+++ b/readmes/README-de.md
@@ -182,7 +182,7 @@ Dieses Projekt befindet sich noch in der aktiven Entwicklung. Beiträge sind aus
 
 ### Star Historie
 
-[![YAMLResume Star History Chart](https://api.star-history.com/svg?repos=yamlresume/yamlresume&type=Date)](https://www.star-history.com/#yamlresume/yamlresume&Date)
+[![YAMLResume Star History Chart](https://star-history.dera.page/svg?repos=yamlresume/yamlresume&type=Date)](https://star-history.dera.page/#yamlresume/yamlresume&Date)
 
 ## Das Projekt unterstützen
 

--- a/readmes/README-es.md
+++ b/readmes/README-es.md
@@ -186,7 +186,7 @@ Este proyecto aún está bajo desarrollo activo. ¡Las contribuciones son profun
 
 ### Historial de Estrellas
 
-[![YAMLResume Star History Chart](https://api.star-history.com/svg?repos=yamlresume/yamlresume&type=Date)](https://www.star-history.com/#yamlresume/yamlresume&Date)
+[![YAMLResume Star History Chart](https://star-history.dera.page/svg?repos=yamlresume/yamlresume&type=Date)](https://star-history.dera.page/#yamlresume/yamlresume&Date)
 
 ## Soporta el Proyecto
 

--- a/readmes/README-fr.md
+++ b/readmes/README-fr.md
@@ -191,7 +191,7 @@ Toute forme de contribution est grandement appréciée ! Merci de lire le
 
 ### Historique des étoiles
 
-[![Courbe d’étoiles YAMLResume](https://api.star-history.com/svg?repos=yamlresume/yamlresume&type=Date)](https://www.star-history.com/#yamlresume/yamlresume&Date)
+[![Courbe d’étoiles YAMLResume](https://star-history.dera.page/svg?repos=yamlresume/yamlresume&type=Date)](https://star-history.dera.page/#yamlresume/yamlresume&Date)
 
 ## Feuille de route
 

--- a/readmes/README-ja.md
+++ b/readmes/README-ja.md
@@ -174,7 +174,7 @@ YAMLResumeは、履歴書をより効率的に作成、変換、管理するた�
 
 ### スター履歴
 
-[![YAMLResume Star History Chart](https://api.star-history.com/svg?repos=yamlresume/yamlresume&type=Date)](https://www.star-history.com/#yamlresume/yamlresume&Date)
+[![YAMLResume Star History Chart](https://star-history.dera.page/svg?repos=yamlresume/yamlresume&type=Date)](https://star-history.dera.page/#yamlresume/yamlresume&Date)
 
 ## ロードマップ
 

--- a/readmes/README-zh-cn.md
+++ b/readmes/README-zh-cn.md
@@ -158,7 +158,7 @@ YAMLResume 采用 [LaTeX](https://www.latex-project.org/) 作为默认排版引�
 
 ### Star 历史
 
-[![YAMLResume Star History Chart](https://api.star-history.com/svg?repos=yamlresume/yamlresume&type=Date)](https://www.star-history.com/#yamlresume/yamlresume&Date)
+[![YAMLResume Star History Chart](https://star-history.dera.page/svg?repos=yamlresume/yamlresume&type=Date)](https://star-history.dera.page/#yamlresume/yamlresume&Date)
 
 ## 路线图
 

--- a/readmes/README-zh-tw.md
+++ b/readmes/README-zh-tw.md
@@ -152,7 +152,7 @@ YAMLResume 採用 [LaTeX](https://www.latex-project.org/) 作為預設排版引�
 
 ### Star 歷史
 
-[![YAMLResume Star History Chart](https://api.star-history.com/svg?repos=yamlresume/yamlresume&type=Date)](https://www.star-history.com/#yamlresume/yamlresume&Date)
+[![YAMLResume Star History Chart](https://star-history.dera.page/svg?repos=yamlresume/yamlresume&type=Date)](https://star-history.dera.page/#yamlresume/yamlresume&Date)
 
 ## 路線圖
 


### PR DESCRIPTION
The star history charts in our README files are no longer rendering due to a broken image source, so the project's growth is no longer visible on the main page.

This PR updates the chart links in the main README and all localized translations (de, es, fr, ja, zh-cn, zh-tw) so the charts work again. The Portuguese and Indonesian READMEs already have no chart and were left unchanged.