### PR TITLE
fix(docker): register TeX Live's font trees with fontconfig

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -12,4 +12,11 @@ RUN apt update && \
     && rm -rf /usr/share/texlive/texmf-dist/source \
     && rm -rf /usr/share/texlive/texmf-dist/fonts/type1
 
+# Expose TeX Live's font trees to fontconfig: fontspec resolves
+# typography.fontFamily by family name, but texmf-dist is only kpathsea-indexed.
+RUN ln -s /usr/share/texlive/texmf-dist/fonts/opentype /usr/share/fonts/opentype/texlive \
+    && ln -s /usr/share/texlive/texmf-dist/fonts/truetype /usr/share/fonts/truetype/texlive \
+    && fc-cache -f \
+    && fc-match "IBM Plex Sans" # plex ships only in these trees, so this fails the build on stale symlinks
+
 LABEL maintainer="YAMLResume <https://yamlresume.dev>"


### PR DESCRIPTION
## Summary

The LaTeX engine resolves `typography.fontFamily` values by **family name**
through fontspec's `\IfFontExistsTF`, which consults **fontconfig** — but every
font shipped via `texlive-fonts-extra` lives under `texmf-dist`, which is only
indexed by **kpathsea**. The base image therefore silently falls back to Linux
Libertine for any `fontFamily` that Debian doesn't package separately — for
example `IBM Plex Sans`:

```
$ pdffonts plex-repro.pdf        # fontFamily: IBM Plex Sans, unfixed image
CEESOZ+LinLibertineOZ-Identity-H     CID Type 0C       Identity-H       yes yes yes
OOHJIG+LinLibertineO-Identity-H      CID Type 0C       Identity-H       yes yes yes
```

Rather than special-casing individual fonts, this PR exposes TeX Live's whole
font inventory to fontconfig: symlink the `texmf-dist` opentype/truetype trees
into `/usr/share/fonts` and refresh the cache. This makes `typography.fontFamily`
work for every texlive-shipped family, on whichever Debian release the base
image uses.

## Notes

- Symlinks, not copies: the image does not grow. `fc-cache` over the trees adds
  ~4.5s to the build.
- No released Debian suite carries an IBM Plex package — `fonts-ibm-plex`
  exists only in unstable (verified against the apt indexes of bookworm and
  trixie), so installing the fonts via apt is not currently an option.
- Debian-packaged fonts (`Linux Libertine`, `Noto`) are unaffected: they are
  registered under `/usr/share/fonts` as before.

## Verification

Against the published `yamlresume/yamlresume-base:v1.0.0` image with
`yamlresume@0.16.0`, applying the two `ln -s` commands and `fc-cache -f`:

```
$ fc-list : family | sort -u | wc -l
1464        # was 525

$ fc-match "IBM Plex Sans"
IBMPlexSans-Regular.otf: "IBM Plex Sans" "Regular"

$ fc-match "TeX Gyre Termes"     # another texlive-only family
texgyretermes-regular.otf: "TeX Gyre Termes" "Regular"

$ pdffonts plex-repro.pdf        # same resume as above, now with the fix
PCIQAM+IBMPlexSans-Bold-Identity-H   CID Type 0C       Identity-H       yes yes yes
XSZASM+IBMPlexSans-Identity-H        CID Type 0C       Identity-H       yes yes yes
```

The build-time `fc-match` assertion makes the image build fail fast if the
font paths ever move.
